### PR TITLE
Bugfix: PHP 7 doesn't allow String as a classname

### DIFF
--- a/src/Didww/API2/Object.php
+++ b/src/Didww/API2/Object.php
@@ -73,7 +73,7 @@ abstract class Object implements \Didww\Utils\ArrayTransform
     {
         $result = array();
         foreach ($array as $key => $value) {
-            $property = \Didww\Utils\String::camelCase($key);
+            $property = \Didww\Utils\StringUtil::camelCase($key);
 
             $setter = "set" . ucfirst($property);
 
@@ -137,7 +137,7 @@ abstract class Object implements \Didww\Utils\ArrayTransform
             if ($value instanceof Object) {
                 $value = $value->toArray($options);
             }
-            $result[\Didww\Utils\String::snakeCase($key)] = $value;
+            $result[\Didww\Utils\StringUtil::snakeCase($key)] = $value;
         }
         return $result;
     }
@@ -180,4 +180,3 @@ abstract class Object implements \Didww\Utils\ArrayTransform
 
 }
 
- 

--- a/src/Didww/Utils/StringUtil.php
+++ b/src/Didww/Utils/StringUtil.php
@@ -30,7 +30,7 @@
 namespace Didww\Utils;
 
 /**
- * String
+ * StringUtil
  *
  * @category DIDWW
  * @package Utils
@@ -39,12 +39,12 @@ namespace Didww\Utils;
  * @license MIT
  */
 
-class String
+class StringUtil
 {
     /**
      * Camelize (or Pascalize) a string
      *
-     * @example <code>\Didww\Utils\String::camelCase('my_database_field', true);// => MyDatabaseField</code>
+     * @example <code>\Didww\Utils\StringUtil::camelCase('my_database_field', true);// => MyDatabaseField</code>
      *
      * @param string $string The string to camelize
      * @param boolean $lcfirst [optional] First char must be lowercase ? Default is false
@@ -63,7 +63,7 @@ class String
     /**
      * Convert a camel cased or pascal cased string to a snake cased string (with _ for separator)
      *
-     * @example <code>\Didww\Utils\String::snakeCase('myDatabaseField');// => my_database_field</code>
+     * @example <code>\Didww\Utils\StringUtil::snakeCase('myDatabaseField');// => my_database_field</code>
      *
      * @param string $string The string to snake case
      * @return string           Snake cased string


### PR DESCRIPTION
Since PHP 7 `String` is not allowed as classname anymore. When trying to run any function you will get:
```
PHP Fatal error:  Cannot use 'String' as class name as it is reserved
```
This pull request replaces it with `StringUtil`. 