### PR TITLE
Update to PHPUnit 6.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3",
-        "phpunit/phpunit": "4.0.*",
+        "phpunit/phpunit": "6.2.*",
         "php-vcr/php-vcr": "1.*"
     },
     "require-dev": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,7 +7,7 @@ use Didww\API2\ApiCredentials, Didww\API2\ApiClient as Client;
 \VCR\VCR::turnOn(); // Important. Must be here, because of SOAP-requests
 
 
-class BaseTest extends \PHPUnit_Framework_TestCase
+class BaseTest extends PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {


### PR DESCRIPTION
Simple update for PHPUnit, tests are passing.  v6.2 is current stable version for [PHPUnit](https://phpunit.de/).